### PR TITLE
Add templateM8-legend to palette-loop

### DIFF
--- a/templateM8/dca/tl_content.php
+++ b/templateM8/dca/tl_content.php
@@ -40,7 +40,7 @@ foreach($GLOBALS['TL_DCA']['tl_content']['palettes'] as $k => $v)
 {
     if(!is_array($v))
     {
-        $GLOBALS['TL_DCA']['tl_content']['palettes'][$k] .= ',templateM8;';
+        $GLOBALS['TL_DCA']['tl_content']['palettes'][$k] .= ';{templateMate_legend:hide},templateM8;';
     }
 }
 


### PR DESCRIPTION
Inside the foreach palette-loop the templateM8-legend was missing. This caused a visual error in the templateM8-section in the backend.