### PR TITLE
Remove redundant templateM8-extension for text and image

### DIFF
--- a/templateM8/dca/tl_content.php
+++ b/templateM8/dca/tl_content.php
@@ -33,9 +33,6 @@
  * Table tl_content
  */
 
-$GLOBALS['TL_DCA']['tl_content']['palettes']['text'] = $GLOBALS['TL_DCA']['tl_content']['palettes']['text'].';{templateMate_legend:hide},templateMate;';
-$GLOBALS['TL_DCA']['tl_content']['palettes']['image'] = $GLOBALS['TL_DCA']['tl_content']['palettes']['image'].';{templateMate_legend:hide},templateMate;';
-
 foreach($GLOBALS['TL_DCA']['tl_content']['palettes'] as $k => $v)
 {
     if(!is_array($v))


### PR DESCRIPTION
Removed the redundant templateM8-extension for text and image content elements, since they are handled by the foreach palette loop.